### PR TITLE
Dynamic Frame Delay depending on Client Max Frame Rate in IPVideoRoute

### DIFF
--- a/libs/ofxHTTP/src/IPVideoRoute.cpp
+++ b/libs/ofxHTTP/src/IPVideoRoute.cpp
@@ -358,7 +358,8 @@ void IPVideoRoute::removeConnection(IPVideoConnection* handler)
 
 IPVideoConnection::IPVideoConnection(IPVideoRoute& route):
     BaseRouteHandler_<IPVideoRoute>(route),
-    IPVideoFrameQueue(route.settings().getMaxClientQueueSize())
+    IPVideoFrameQueue(route.settings().getMaxClientQueueSize()),
+    _targetFrameDuration(1000 / route.settings().getMaxClientFrameRate())
 {
 }
 
@@ -399,7 +400,7 @@ void IPVideoConnection::handleRequest(ServerEventArgs& evt)
 
 
     Poco::Net::NameValueCollection queryMap = HTTPUtils::getQueryMap(uri);
-
+ 
     if (queryMap.has("vflip"))
     {
         std::string vflip = queryMap.get("vflip");
@@ -495,10 +496,13 @@ void IPVideoConnection::handleRequest(ServerEventArgs& evt)
         
         while (_isRunning)
         {
+            uint64_t frameSendStart = ofGetElapsedTimeMillis();
+            
             if (outputStream.good() && !outputStream.fail() && !outputStream.bad())
             {
                 if (!empty())
                 {
+                    _nextScheduledFrame = frameSendStart + _targetFrameDuration;
                     std::shared_ptr<IPVideoFrame> frame = pop();
                     
                     if (frame != nullptr)
@@ -514,10 +518,11 @@ void IPVideoConnection::handleRequest(ServerEventArgs& evt)
                         ostr << "\r\n";
                         ostr << buffer;
                         
-                        uint64_t now = ofGetElapsedTimeMillis();
-                        _lastFrameDuration = now - _lastFrameSent;
-                        _lastFrameSent = now;
+//                        uint64_t now = ofGetElapsedTimeMillis();
+//                        _lastFrameDuration = now - _lastFrameSent;
+//                        _lastFrameSent = now;
                         _bytesSent += static_cast<uint64_t>(ostr.chars()); // add the counts
+                        _framesSent ++;
                         ostr.reset();               // reset the counts
                         ostr.flush();
                     }
@@ -529,14 +534,18 @@ void IPVideoConnection::handleRequest(ServerEventArgs& evt)
                 else
                 {
                     // ofLogVerbose("IPVideoRouteHandler::handleRequest") << "Queue empty.";
+                    // Delay a little bit to wait for a next frame to come into the queue.
+                    _nextScheduledFrame = frameSendStart + 10;
                 }
             }
             else
             {
                 throw Poco::Exception("Response stream failed or went bad -- it was probably interrupted.");
             }
-            
-            Poco::Thread::sleep(30);  // TODO: smarter ways of doing for rate / fps limiting
+            uint64_t now = ofGetElapsedTimeMillis();
+            if (now < _nextScheduledFrame) {
+                Poco::Thread::sleep(_nextScheduledFrame - now);
+            }
         }
     }
     catch (const Poco::Exception& e)


### PR DESCRIPTION
In regards to:

> TODO: smarter ways of doing for rate / fps limiting

The code in this PR updates the way the `handleRequest` thread sleeps to attempt to keep a steady fps with shorter waits for an empty queue.

I looked at the vars in IPVideoConnection and tried to guess at what the original design was, but saw that many aren't being used at all.  